### PR TITLE
Add Bootstrap website

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <title>Perl Ad Server</title>
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/5.2.3/css/bootstrap.min.css">
+</head>
+<body>
+  <header class="bg-primary text-white text-center py-3">
+    <h1>Perl Ad Server</h1>
+  </header>
+  <main class="container my-5">
+    <div class="row">
+      <div class="col">
+        <p>Welcome to the Perl Ad Server. More content will be added soon.</p>
+      </div>
+    </div>
+  </main>
+  <footer class="bg-light text-center py-3">
+    <p>&copy; 2024 Perl Tools Team. <a href="https://github.com/PerlToolsTeam">Perl Tools Team</a></p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
Fixes #1

Add a new web page for the Perl Ad Server using Bootstrap.

* Create a new directory `docs` to store the web site files.
* Add `docs/index.html` with the following content:
  - Use Bootstrap 5.2.3 for styling.
  - Set the title of the page to "Perl Ad Server".
  - Create a single page layout with a header, main content area, and footer.
  - Add a footer with the text "Copyright 2024, Perl Tools Team" and a link to the GitHub org.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PerlToolsTeam/perl-ads/issues/1?shareId=b3e21f4e-5f44-409f-9d80-75050e7423ef).