### PR TITLE
Add JSON file for London Perl Workshop

### DIFF
--- a/docs/perl-ads.js
+++ b/docs/perl-ads.js
@@ -1,5 +1,5 @@
 document.addEventListener("DOMContentLoaded", function() {
-  fetch('https://perl-ads.perlhacks.com/perl-ads.json')
+  fetch('/perl-ads.json')
     .then(response => {
       if (response.status === 404) {
         return null;

--- a/docs/perl-ads.json
+++ b/docs/perl-ads.json
@@ -1,0 +1,5 @@
+{
+  "title": "London Perl Workshop",
+  "description": "Back after a five year break",
+  "link": "https://act.yapc.eu/lpw2024/"
+}


### PR DESCRIPTION
Fixes #6

Add JSON file for London Perl Workshop and update fetch URL in JavaScript.

* Add `docs/perl-ads.json` with title, description, and link for London Perl Workshop.
* Update `docs/perl-ads.js` to fetch JSON file from local path `/perl-ads.json` instead of external URL.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PerlToolsTeam/perl-ads/issues/6?shareId=0cc1b8fa-84e6-47a1-8d29-3c2ae54a1630).