### PR TITLE
Fix formatting

### DIFF
--- a/docs/perl-ads.js
+++ b/docs/perl-ads.js
@@ -13,10 +13,8 @@ document.addEventListener("DOMContentLoaded", function() {
 
       const adFragment = document.createElement('div');
       adFragment.innerHTML = `
-        <div class="ad">
-          <h2>${data.title}</h2>
-          <p>${data.description}</p>
-          <a href="${data.link}">Learn more</a>
+        <div class="ad text-center">
+          <p><span style="font-weight: bold;">${data.title}</span> ${data.description} <a href="${data.link}">Learn more</a></p>
         </div>
       `;
 


### PR DESCRIPTION
Fixes #8

Update ad formatting in `docs/perl-ads.js`

* Replace `<h2>` tag with `<span>` tag for the title and add `font-weight: bold;` style.
* Combine title, description, and link into a single `<p>` tag.
* Add `text-center` class to the `<div>` containing the ad.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PerlToolsTeam/perl-ads/issues/8?shareId=4ac8b1fc-c722-4dd4-bae1-fb91fb44ac66).