### PR TITLE
More formatting

### DIFF
--- a/docs/perl-ads.js
+++ b/docs/perl-ads.js
@@ -14,7 +14,7 @@ document.addEventListener("DOMContentLoaded", function() {
       const adFragment = document.createElement('div');
       adFragment.innerHTML = `
         <div class="ad text-center">
-          <p><span style="font-weight: bold;">${data.title}</span> ${data.description} <a href="${data.link}">Learn more</a></p>
+          <p><span style="font-weight: bold;">${data.title}:</span> ${data.description} <a href="${data.link}" target="_blank">Learn more</a></p>
         </div>
       `;
 


### PR DESCRIPTION
Fixes #10

Add a bold colon after the title and open the link in a new window/tab.

* Add a bold colon after the title in the `innerHTML` template string in `docs/perl-ads.js`.
* Add `target="_blank"` attribute to the link in the `innerHTML` template string in `docs/perl-ads.js`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PerlToolsTeam/perl-ads/issues/10?shareId=541add9e-25f0-4f61-8463-367cef928f2c).