### PR TITLE
More formatting for advert

### DIFF
--- a/docs/perl-ads.js
+++ b/docs/perl-ads.js
@@ -13,8 +13,8 @@ document.addEventListener("DOMContentLoaded", function() {
 
       const adFragment = document.createElement('div');
       adFragment.innerHTML = `
-        <div class="ad text-center">
-          <p><span style="font-weight: bold;">${data.title}:</span> ${data.description} <a href="${data.link}" target="_blank">Learn more</a></p>
+        <div class="ad text-center mt-3 mb-1">
+          <p class="fw-bold">${data.title}:</p> ${data.description} <a href="${data.link}" target="_blank">Learn more</a>
         </div>
       `;
 


### PR DESCRIPTION
Fixes #12

Add Bootstrap utility classes for styling the advert in `docs/perl-ads.js`.

* Add `mt-3` Bootstrap utility class to the `div` element containing the advert to add more space above the advert.
* Add `mb-1` Bootstrap utility class to the `div` element containing the advert to reduce space below the advert.
* Remove inline styles from the `p` element and use the `fw-bold` Bootstrap utility class for bold text.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PerlToolsTeam/perl-ads/issues/12?shareId=ad8cc4d3-c564-40e2-9f53-dbcff51307f3).