### PR TITLE
fix the invalid URL in an ad

### DIFF
--- a/docs/perl-ads.json
+++ b/docs/perl-ads.json
@@ -7,6 +7,6 @@
   {
     "title": "Dave Cross: Still Munging Data With Perl",
     "description": "Online event - Mar 17",
-    "link": "ihttps://lu.ma/3b8ekn8y"
+    "link": "https://lu.ma/3b8ekn8y"
   }
 ]


### PR DESCRIPTION
There was an ad url that started with ihttps. This fixes that (fixes issue #17 )