### PR TITLE
Prefer a div with the id perl-ad-target

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -78,6 +78,6 @@
           crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.25.0/prism.min.js"></script>
   <script src="/js/script.js"></script>
-  <script src="https://perl-ads.perlhacks.com/perl-ads.js"></script>
+  <script src="/perl-ads.js"></script>
 </body>
 </html>

--- a/docs/perl-ads.js
+++ b/docs/perl-ads.js
@@ -63,7 +63,12 @@ document.addEventListener("DOMContentLoaded", function() {
 
     adContainer.appendChild(adParagraph);
 
-    document.body.insertBefore(adContainer, document.body.firstChild);
+    const target = document.getElementById('perl-ad-target');
+    if (target) {
+      target.appendChild(adContainer);
+    } else {
+      document.body.insertBefore(adContainer, document.body.firstChild);
+    }
   };
 
   const storedAds = localStorage.getItem(storageKey);


### PR DESCRIPTION
Rather than injecting the ad right at the top of the page, allow it to
be embedded at an arbitrary place and then fall back to the original
behaviour.
