### PR TITLE
Add dates to ads

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -63,6 +63,10 @@
         <p>If you find you need anything else, then please
           <a href="https://github.com/PerlToolsTeam/perl-ads/issues">raise an issue</a>
           and we'll see what we can do.</p>
+        <h2>Date Format for Ads</h2>
+        <p>The JSON objects for ads can include optional <tt>start</tt> and <tt>end</tt> keys to specify the date range during which the ad should be displayed. These keys are optional, but if provided, they must follow the specified date format.</p>
+        <p>The date format for the <tt>start</tt> and <tt>end</tt> keys is <tt>YYYY-MM-DD</tt>. For example, a valid date would be <tt>2025-06-27</tt>.</p>
+        <p>Ads without <tt>start</tt> and <tt>end</tt> keys are considered always valid and will be displayed regardless of the current date.</p>
       </div>
       <div class="col-2"></div> <!-- Empty column for right margin -->
     </div>

--- a/docs/perl-ads.js
+++ b/docs/perl-ads.js
@@ -35,7 +35,27 @@ function initializeAds() {
   };
 
   const displayAd = (data) => {
-    const randomAd = data[Math.floor(Math.random() * data.length)];
+    const currentDate = new Date().toISOString().split('T')[0]; // Get current date in YYYY-MM-DD format
+    const validAds = data.filter(ad => {
+      const startDate = ad.start ? new Date(ad.start) : null;
+      const endDate = ad.end ? new Date(ad.end) : null;
+
+      if (startDate && endDate) {
+        return currentDate >= ad.start && currentDate <= ad.end;
+      } else if (startDate) {
+        return currentDate >= ad.start;
+      } else if (endDate) {
+        return currentDate <= ad.end;
+      } else {
+        return true; // Ads without start and end dates are always valid
+      }
+    });
+
+    if (validAds.length === 0) {
+      return; // No valid ads to display
+    }
+
+    const randomAd = validAds[Math.floor(Math.random() * validAds.length)];
 
     const adContainer = document.createElement('div');
     adContainer.id = 'perl-ad';


### PR DESCRIPTION
Fixes #26

Add date-based filtering for ads in `docs/index.html` and `docs/perl-ads.js`.

* **docs/index.html**
  - Add a section to specify the date format for the `start` and `end` keys.
  - Mention that the `start` and `end` keys are optional but must follow the specified date format if provided.
  - Provide an example of a valid date format in the documentation, such as "YYYY-MM-DD".

* **docs/perl-ads.js**
  - Fetch the current date and compare it with the `start` and `end` dates to determine if an ad is within the valid date range.
  - Update the `displayAd` function to check the `start` and `end` keys and only display ads that are within the valid date range.
  - Consider ads without `start` and `end` keys as always valid and display them regardless of the current date.
  - Filter out ads that are out of date and only display valid ads.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PerlToolsTeam/perl-ads/pull/27?shareId=a7bb72a4-3057-4ec5-945c-7859460abcab).