### PR TITLE
Add npm publishing via GitHub Actions

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,22 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -5,18 +5,34 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
+      - name: Bump version
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          npm version ${{ inputs.bump }}
+          git push --follow-tags
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "perl-ads",
+  "version": "1.0.0",
+  "description": "A tiny banner for Perl community announcements",
+  "main": "docs/perl-ads.js",
+  "files": [
+    "docs/perl-ads.js"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/PerlToolsTeam/perl-ads.git"
+  },
+  "homepage": "https://perl-ads.perlhacks.com",
+  "keywords": [
+    "perl",
+    "ads",
+    "banner",
+    "community"
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `package.json` to publish `perl-ads` to npm (only `docs/perl-ads.js` is included)
- Add GitHub Actions workflow that publishes on tag pushes (`v*`) and manual `workflow_dispatch`

## Setup required
1. Add an npm automation token as a repo secret named `NPM_TOKEN` (Settings > Secrets > Actions)
2. Do the first publish manually (`npm publish`) to claim the `perl-ads` package name, or just push a `v1.0.0` tag after merging

## Usage
To publish a new version:
```bash
npm version patch   # 1.0.0 → 1.0.1 (or: minor, major)
git push --follow-tags
```
`npm version` bumps `package.json`, commits, and creates the git tag automatically. The tag push triggers the publish workflow.

Or trigger manually from Actions > "Publish to npm" > Run workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)